### PR TITLE
hw 1

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -43,6 +43,7 @@ class PaymentExternalSystemAdapterImpl(
     )
 
     override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        logger.warn("[$accountName] Submitting payment request for payment $paymentId")
         if (System.currentTimeMillis() > deadline) {
             logger.warn("[$accountName] Payment $paymentId already expired before processing")
             paymentESService.update(paymentId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ management.endpoints.web.exposure.include=info,health,prometheus,metrics
 
 payment.service-name=${PAYMENT_SERVICE_NAME}
 payment.token=${PAYMENT_TOKEN}
-payment.accounts=${PAYMENT_ACCOUNTS:acc-12,acc-20}
+payment.accounts=${PAYMENT_ACCOUNTS:acc-3}
 payment.hostPort=${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}


### PR DESCRIPTION
1. Тесты проходили на 90 процентов, падали на timeout exceeded
2. Кейс с заданными параметрами генерирует нагрузку в 11 тестов в секунду, когда по свойствам аккаунта он может обработать максимум 10. Все запросы шли сразу без ограничений и аккаунт просто реджектил лишние
3. Внесены изменения в PaymentExternalSystemAdapterImpl, а именно добавлен лимитер, который ограничивает количество тестов в секунду по параметру, полученному из свойств аккаунта. Так же перед отправкой проверяется дедлайн события, чтобы "протухшие" из-за ожидания тика лимитера не отправлялись в платежную систему
4. 11-й запрос в секунду ждет освобождения слота в rate limiter, просроченные запросы отклоняются без отправки. Теперь проходит в среднем 98-100 процентов тестов